### PR TITLE
Make QuadKey a type

### DIFF
--- a/quadtree/quadkey.go
+++ b/quadtree/quadkey.go
@@ -9,7 +9,7 @@ import (
 
 type QuadKey uint64
 
-// GetParentQuadKey get parents quadkey for passed quadkey
+// Parent get parents quadkey for passed quadkey
 func (q QuadKey) Parent() (QuadKey, error) {
 	zoomLevel := q & 0xFF
 	parentZoomLevel := zoomLevel - 1
@@ -26,7 +26,7 @@ func (q QuadKey) Parent() (QuadKey, error) {
 	return parent, nil
 }
 
-// GetChildQuadKeyForPos where pos is 0-3
+// ChildAtPos where pos is 0-3
 // based off https://learn.microsoft.com/en-us/bingmaps/articles/bing-maps-tile-system?redirectedfrom=MSDN
 func (q QuadKey) ChildAtPos(pos int) (QuadKey, error) {
 	zoomLevel := q & 0xFF
@@ -53,7 +53,7 @@ func (q QuadKey) ChildAtPos(pos int) (QuadKey, error) {
 	return q, nil
 }
 
-// GetChildrenQuadKeys get all the quadkeys for the 4 children of the passed quadkey
+// Children get all the quadkeys for the 4 children of the passed quadkey
 func (q QuadKey) Children() []QuadKey {
 	var children []QuadKey
 	for i := 0; i < 4; i++ {
@@ -80,7 +80,7 @@ func GenerateQuadKeyIndexFromSlippy(x uint32, y uint32, zoomLevel byte) QuadKey 
 	return binaryQuadkey
 }
 
-// GenerateSlippyCoordsFromQuadKeyIndex generates the slippy coords from quadkey index
+// SlippyCoords generates the slippy coords from quadkey index
 func (q QuadKey) SlippyCoords() (int32, int32, byte) {
 	var x int32
 	var y int32
@@ -113,7 +113,7 @@ func (q QuadKey) SlippyCoords() (int32, int32, byte) {
 	return x, y, zoomLevel
 }
 
-// GetTileZoomLevel get the zoom level of the quadkey
+// Zoom get the zoom level of the quadkey
 func (q QuadKey) Zoom() byte {
 	zoomLevel := byte(q & 0xFF)
 	return zoomLevel

--- a/quadtree/quadkey.go
+++ b/quadtree/quadkey.go
@@ -7,9 +7,11 @@ import (
 
 // Misc functions for generating/calculating quadkeys
 
+type QuadKey uint64
+
 // GetParentQuadKey get parents quadkey for passed quadkey
-func GetParentQuadKey(quadKey uint64) (uint64, error) {
-	zoomLevel := quadKey & 0xFF
+func (q QuadKey) Parent() (QuadKey, error) {
+	zoomLevel := q & 0xFF
 	parentZoomLevel := zoomLevel - 1
 
 	if parentZoomLevel <= 0 {
@@ -17,79 +19,79 @@ func GetParentQuadKey(quadKey uint64) (uint64, error) {
 	}
 
 	shift := 64 - (parentZoomLevel * 2)
-	parentQuadKey := quadKey >> shift
-	parentQuadKey = parentQuadKey << shift
-	parentQuadKey |= uint64(parentZoomLevel)
+	parent := q >> shift
+	parent = parent << shift
+	parent |= parentZoomLevel
 
-	return parentQuadKey, nil
+	return parent, nil
 }
 
 // GetChildQuadKeyForPos where pos is 0-3
 // based off https://learn.microsoft.com/en-us/bingmaps/articles/bing-maps-tile-system?redirectedfrom=MSDN
-func GetChildQuadKeyForPos(quadKey uint64, pos int) (uint64, error) {
-	zoomLevel := quadKey & 0xFF
+func (q QuadKey) ChildAtPos(pos int) (QuadKey, error) {
+	zoomLevel := q & 0xFF
 
 	rightShift := 63 - (zoomLevel * 2) + 1
-	quadKey = quadKey >> rightShift
+	q = q >> rightShift
 
 	switch pos {
 	case 0:
-		quadKey = quadKey << 2
+		q = q << 2
 	case 1:
-		quadKey = (quadKey << 2) | 0b01
+		q = (q << 2) | 0b01
 	case 2:
-		quadKey = (quadKey << 2) | 0b10
+		q = (q << 2) | 0b10
 	case 3:
-		quadKey = (quadKey << 2) | 0b11
+		q = (q << 2) | 0b11
 	default:
 		return 0, errors.New(fmt.Sprintf("invalid pos %d", pos))
 	}
 
-	quadKey = quadKey << (64 - (zoomLevel * 2) - 2)
+	q = q << (64 - (zoomLevel * 2) - 2)
 
-	quadKey |= uint64(zoomLevel + 1)
-	return quadKey, nil
+	q |= zoomLevel + 1
+	return q, nil
 }
 
 // GetChildrenQuadKeys get all the quadkeys for the 4 children of the passed quadkey
-func GetChildrenQuadKeys(quadKey uint64) []uint64 {
-	var quadKeys []uint64
+func (q QuadKey) Children() []QuadKey {
+	var children []QuadKey
 	for i := 0; i < 4; i++ {
-		quadKey, _ := GetChildQuadKeyForPos(quadKey, i)
-		quadKeys = append(quadKeys, quadKey)
+		child, _ := q.ChildAtPos(i)
+		children = append(children, child)
 	}
-	return quadKeys
+	return children
 }
 
 // GenerateQuadKeyIndexFromSlippy generates the quadkey index from slippy coords
-func GenerateQuadKeyIndexFromSlippy(x uint32, y uint32, zoomLevel byte) uint64 {
-	var binaryQuadkey uint64
+func GenerateQuadKeyIndexFromSlippy(x uint32, y uint32, zoomLevel byte) QuadKey {
+	var binaryQuadkey QuadKey
 	for i := zoomLevel; i > 0; i-- {
 		var mask uint32 = 1 << (i - 1)
-		var bitLocation uint64 = 64 - (uint64(zoomLevel-i+1) * 2) + 1
+		var bitLocation QuadKey = 64 - (QuadKey(zoomLevel-i+1) * 2) + 1
 		if x&mask != 0 {
-			binaryQuadkey |= uint64(0b1) << (bitLocation - 1)
+			binaryQuadkey |= 0b1 << (bitLocation - 1)
 		}
 		if y&mask != 0 {
-			binaryQuadkey |= uint64(0b1) << bitLocation
+			binaryQuadkey |= 0b1 << bitLocation
 		}
 	}
-	binaryQuadkey |= uint64(zoomLevel)
+	binaryQuadkey |= QuadKey(zoomLevel)
 	return binaryQuadkey
 }
 
 // GenerateSlippyCoordsFromQuadKeyIndex generates the slippy coords from quadkey index
-func GenerateSlippyCoordsFromQuadKey(quadKey uint64) (int32, int32, byte) {
+func (q QuadKey) SlippyCoords() (int32, int32, byte) {
 	var x int32
 	var y int32
 
-	zoomLevel := GetTileZoomLevel(quadKey)
+	zoomLevel := q.Zoom()
 
 	minPos := 64 - (int(zoomLevel) * 2)
 	for i := 63; i > minPos; i -= 2 {
 
-		firstBit := (quadKey >> i) & 1
-		secondBit := (quadKey >> (i - 1)) & 1
+		firstBit := (q >> i) & 1
+		secondBit := (q >> (i - 1)) & 1
 		twoBits := (firstBit << 1) | secondBit
 		switch twoBits {
 
@@ -112,7 +114,7 @@ func GenerateSlippyCoordsFromQuadKey(quadKey uint64) (int32, int32, byte) {
 }
 
 // GetTileZoomLevel get the zoom level of the quadkey
-func GetTileZoomLevel(quadKey uint64) byte {
-	zoomLevel := byte(quadKey & 0xFF)
+func (q QuadKey) Zoom() byte {
+	zoomLevel := byte(q & 0xFF)
 	return zoomLevel
 }

--- a/quadtree/quadkey_test.go
+++ b/quadtree/quadkey_test.go
@@ -9,29 +9,28 @@ import (
 const (
 
 	// levels 1-6 are populated (first 12 bits) and can see level (6) indicated at end of binary
-	QuadKey uint64 = 0b1101110110110000000000000000000000000000000000000000000000000110
+	quadKey QuadKey = 0b1101110110110000000000000000000000000000000000000000000000000110
 
 	// children of QuadKey. Note bits 12 and 13 as well as zoom at end.
-	Child0 uint64 = 0b1101110110110000000000000000000000000000000000000000000000000111
-	Child1 uint64 = 0b1101110110110100000000000000000000000000000000000000000000000111
-	Child2 uint64 = 0b1101110110111000000000000000000000000000000000000000000000000111
-	Child3 uint64 = 0b1101110110111100000000000000000000000000000000000000000000000111
+	Child0 QuadKey = 0b1101110110110000000000000000000000000000000000000000000000000111
+	Child1 QuadKey = 0b1101110110110100000000000000000000000000000000000000000000000111
+	Child2 QuadKey = 0b1101110110111000000000000000000000000000000000000000000000000111
+	Child3 QuadKey = 0b1101110110111100000000000000000000000000000000000000000000000111
 
 	// Parent is same as Quadkey but bits 10-11 are zeroed and length (at end of binary) now reads 5
-	ParentQuadKey uint64 = 0b1101110110000000000000000000000000000000000000000000000000000101
+	parent QuadKey = 0b1101110110000000000000000000000000000000000000000000000000000101
 )
 
 // TestGetParentQuadKey checks parent calculation is correct
 func TestGetParentQuadKey(t *testing.T) {
 
 	// confirm we've got zoom 6
-	zoom := GetTileZoomLevel(QuadKey)
-	assert.Equal(t, uint8(6), zoom, "Zoom level should be 6")
+	assert.Equal(t, uint8(6), quadKey.Zoom(), "Zoom level should be 6")
 
-	parentQuadKey, err := GetParentQuadKey(QuadKey)
+	parentQuadKey, err := quadKey.Parent()
 	assert.Nil(t, err, "Should not have error when getting parent quadkey")
-	assert.Equal(t, ParentQuadKey, parentQuadKey, "Parent quadkey incorrect")
-	assert.Equal(t, uint8(5), GetTileZoomLevel(parentQuadKey), "Parent zoom level should be 5")
+	assert.Equal(t, parent, parentQuadKey, "Parent quadkey incorrect")
+	assert.Equal(t, uint8(5), parentQuadKey.Zoom(), "Parent zoom level should be 5")
 
 }
 
@@ -41,27 +40,26 @@ func TestGetParentQuadKey(t *testing.T) {
 func TestGetChildQuadKeyForPos(t *testing.T) {
 
 	// confirm we've got zoom 6
-	zoom := GetTileZoomLevel(QuadKey)
-	assert.Equal(t, uint8(6), zoom, "Zoom level should be 6")
+	assert.Equal(t, uint8(6), quadKey.Zoom(), "Zoom level should be 6")
 
-	childPos0, err := GetChildQuadKeyForPos(QuadKey, 0)
+	childPos0, err := quadKey.ChildAtPos(0)
 	assert.Nil(t, err, "Should not have error when getting child quadkey")
 	assert.Equal(t, Child0, childPos0, "Child quadkey incorrect")
-	assert.Equal(t, uint8(7), GetTileZoomLevel(childPos0), "Child zoom level should be 7")
+	assert.Equal(t, uint8(7), childPos0.Zoom(), "Child zoom level should be 7")
 
-	childPos1, err := GetChildQuadKeyForPos(QuadKey, 1)
+	childPos1, err := quadKey.ChildAtPos(1)
 	assert.Nil(t, err, "Should not have error when getting child quadkey")
 	assert.Equal(t, Child1, childPos1, "Child quadkey incorrect")
-	assert.Equal(t, uint8(7), GetTileZoomLevel(childPos1), "Child zoom level should be 7")
+	assert.Equal(t, uint8(7), childPos1.Zoom(), "Child zoom level should be 7")
 
-	childPos2, err := GetChildQuadKeyForPos(QuadKey, 2)
+	childPos2, err := quadKey.ChildAtPos(2)
 	assert.Nil(t, err, "Should not have error when getting child quadkey")
 	assert.Equal(t, Child2, childPos2, "Child quadkey incorrect")
-	assert.Equal(t, uint8(7), GetTileZoomLevel(childPos2), "Child zoom level should be 7")
+	assert.Equal(t, uint8(7), childPos2.Zoom(), "Child zoom level should be 7")
 
-	childPos3, err := GetChildQuadKeyForPos(QuadKey, 3)
+	childPos3, err := quadKey.ChildAtPos(3)
 	assert.Nil(t, err, "Should not have error when getting child quadkey")
 	assert.Equal(t, Child3, childPos3, "Child quadkey incorrect")
-	assert.Equal(t, uint8(7), GetTileZoomLevel(childPos3), "Child zoom level should be 7")
+	assert.Equal(t, uint8(7), childPos3.Zoom(), "Child zoom level should be 7")
 
 }

--- a/quadtree/quadmap_test.go
+++ b/quadtree/quadmap_test.go
@@ -50,7 +50,7 @@ func TestHaveTileForSlippyGroupIDAndTileType(t *testing.T) {
 	tile, err = qm.CreateTileAtSlippyCoords(5, 5, 5, 2, 3)
 	assert.NoError(t, err, "Should not have error when adding tile")
 	assert.NotNil(t, tile, "Should have tile")
-	assert.Equal(t, uint64(0xcc0000000000005), tile.QuadKey, "QuadKey incorrect")
+	assert.Equal(t, QuadKey(0xcc0000000000005), tile.QuadKey, "QuadKey incorrect")
 
 	haveTile, err := qm.HaveTileForSlippyGroupIDAndTileType(5, 5, 5, 2, 3)
 	assert.NoError(t, err, "Should not have error when checking tile/group")

--- a/quadtree/quadmap_test.go
+++ b/quadtree/quadmap_test.go
@@ -32,11 +32,11 @@ func TestCreateTileAtSlippyCoords(t *testing.T) {
 	err := qm.AddTile(tile)
 	assert.Nil(t, err, "Should not have error when adding tile")
 
-	// quadindex for 1,1,1 is 0xc000000000000001
+	// quadindex for 1,1,1 is 0b1100000000000000000000000000000000000000000000000000000000000001
 	tile, err = qm.CreateTileAtSlippyCoords(1, 1, 1, 2, 3)
 	assert.NoError(t, err, "Should not have error when adding tile")
 	assert.NotNil(t, tile, "Should have tile")
-	assert.Equal(t, QuadKey(0xc000000000000001), tile.QuadKey, "QuadKey incorrect")
+	assert.Equal(t, QuadKey(0b1100000000000000000000000000000000000000000000000000000000000001), tile.QuadKey, "QuadKey incorrect")
 }
 
 // TestHaveTileForSlippyGroupIDAndTileType create quadmap and adds tile and check if exists
@@ -46,11 +46,11 @@ func TestHaveTileForSlippyGroupIDAndTileType(t *testing.T) {
 	err := qm.AddTile(tile)
 	assert.NoError(t, err, "Should not have error when adding tile")
 
-	// quadindex for 5,5,5 is 0xcc0000000000005
+	// quadindex for 5,5,5 is 0b110011000000000000000000000000000000000000000000000000000101
 	tile, err = qm.CreateTileAtSlippyCoords(5, 5, 5, 2, 3)
 	assert.NoError(t, err, "Should not have error when adding tile")
 	assert.NotNil(t, tile, "Should have tile")
-	assert.Equal(t, QuadKey(0xcc0000000000005), tile.QuadKey, "QuadKey incorrect")
+	assert.Equal(t, QuadKey(0b110011000000000000000000000000000000000000000000000000000101), tile.QuadKey, "QuadKey incorrect")
 
 	haveTile, err := qm.HaveTileForSlippyGroupIDAndTileType(5, 5, 5, 2, 3)
 	assert.NoError(t, err, "Should not have error when checking tile/group")

--- a/quadtree/quadmap_test.go
+++ b/quadtree/quadmap_test.go
@@ -11,7 +11,7 @@ func TestAddTile(t *testing.T) {
 	qm := NewQuadMap(10)
 	tile := NewTile(0, 0, 0)
 	err := qm.AddTile(tile)
-	assert.Nil(t, err, "Should not have error when adding tile")
+	assert.NoError(t, err, "Should not have error when adding tile")
 }
 
 // TestNumberOfTiles create quadmap and adds tile
@@ -19,7 +19,7 @@ func TestNumberOfTiles(t *testing.T) {
 	qm := NewQuadMap(10)
 	tile := NewTile(0, 0, 0)
 	err := qm.AddTile(tile)
-	assert.Nil(t, err, "Should not have error when adding tile")
+	assert.NoError(t, err, "Should not have error when adding tile")
 
 	numTiles := qm.NumberOfTiles()
 	assert.EqualValues(t, 1, numTiles, "Should have 1 tile")
@@ -32,11 +32,11 @@ func TestCreateTileAtSlippyCoords(t *testing.T) {
 	err := qm.AddTile(tile)
 	assert.Nil(t, err, "Should not have error when adding tile")
 
-	// quadindex for 1,1,1 is 13835058055282163713
+	// quadindex for 1,1,1 is 0xc000000000000001
 	tile, err = qm.CreateTileAtSlippyCoords(1, 1, 1, 2, 3)
-	assert.Nil(t, err, "Should not have error when adding tile")
+	assert.NoError(t, err, "Should not have error when adding tile")
 	assert.NotNil(t, tile, "Should have tile")
-	assert.Equal(t, uint64(13835058055282163713), tile.QuadKey, "QuadKey incorrect")
+	assert.Equal(t, QuadKey(0xc000000000000001), tile.QuadKey, "QuadKey incorrect")
 }
 
 // TestHaveTileForSlippyGroupIDAndTileType create quadmap and adds tile and check if exists
@@ -44,19 +44,18 @@ func TestHaveTileForSlippyGroupIDAndTileType(t *testing.T) {
 	qm := NewQuadMap(10)
 	tile := NewTile(0, 0, 0)
 	err := qm.AddTile(tile)
-	assert.Nil(t, err, "Should not have error when adding tile")
+	assert.NoError(t, err, "Should not have error when adding tile")
 
-	// quadindex for 5,5,5 is 918734323983581189
+	// quadindex for 5,5,5 is 0xcc0000000000005
 	tile, err = qm.CreateTileAtSlippyCoords(5, 5, 5, 2, 3)
-	assert.Nil(t, err, "Should not have error when adding tile")
+	assert.NoError(t, err, "Should not have error when adding tile")
 	assert.NotNil(t, tile, "Should have tile")
-	assert.Equal(t, uint64(918734323983581189), tile.QuadKey, "QuadKey incorrect")
+	assert.Equal(t, uint64(0xcc0000000000005), tile.QuadKey, "QuadKey incorrect")
 
 	haveTile, err := qm.HaveTileForSlippyGroupIDAndTileType(5, 5, 5, 2, 3)
-	assert.Nil(t, err, "Should not have error when checking tile/group")
+	assert.NoError(t, err, "Should not have error when checking tile/group")
 	assert.True(t, haveTile, "Should have tile")
 
-	haveTile, err = qm.HaveTileForSlippyGroupIDAndTileType(5, 5, 5, 2, 4)
-	assert.NotNil(t, err, "Should  have error when checking tile/group")
-
+	_, err = qm.HaveTileForSlippyGroupIDAndTileType(5, 5, 5, 2, 4)
+	assert.Error(t, err, "Should have error when checking tile/group")
 }

--- a/quadtree/tile.go
+++ b/quadtree/tile.go
@@ -42,7 +42,7 @@ type GroupDetails struct {
 type Tile struct {
 	// stupid to keep it in here?
 	// Will also store the zoom level in the key.
-	QuadKey uint64
+	QuadKey QuadKey
 
 	// groups that have information for this tile. The IDs listed here can be used elsewhere to look up data.
 	// Not convinced that the groupdata *has* to be stored actually IN the tree.
@@ -89,7 +89,7 @@ func (t *Tile) HasTileType(groupID uint32, tt TileType) bool {
 
 // GetTileZoomLevel returns zoom level of tile
 func (t *Tile) GetTileZoomLevel() byte {
-	return GetTileZoomLevel(t.QuadKey)
+	return t.QuadKey.Zoom()
 }
 
 // SetFullForGroupIDAndTileType sets the full flag for a given tile type.


### PR DESCRIPTION
Make `QuadKey` a type instead of passing `uint64` around everywhere.

I made some stylistic changes along with this... Feel free to push back on _literally anything_ (I can see we're going to clash over the length of function names :wink:) but the core part of `uint64` -> `QuadKey` is I think pretty solid.

After this I'll start porting some changes over from https://github.com/nearmap/geolibsf/tree/quadtree-indexed/quadindex. They're pretty closely compatible apart from storing the zoom level in the bottom bits (which is a good idea) so it should port over pretty well.